### PR TITLE
CLI#init checking ~/.tumblr existent

### DIFF
--- a/lib/tumblfetch/cli.rb
+++ b/lib/tumblfetch/cli.rb
@@ -10,6 +10,11 @@ class CLI < Thor
 `.tumblfetch` has been placed in this directory.
   EOS
 
+  EXECUTE_TUMBLR_MSG =<<-EOS
+`~/.tumblr` can't be found. Run `tumblr` for generating it.
+For details, see https://github.com/tumblr/tumblr_client#the-irb-console
+  EOS
+
   desc 'version', 'Print a version'
   def version
     puts Tumblfetch::VERSION
@@ -17,13 +22,17 @@ class CLI < Thor
 
   desc 'init', 'Generate a .tumblfetch'
   def init
-    if File.exist?('./.tumblfetch')
-      $stderr.puts(SETTINGS_EXIST_MSG)
-    else
-      File.open('./.tumblfetch', 'w') do |file|
-        Tumblfetch.write_settings_template_to(file)
+    if File.exist?(File.join(ENV['HOME'], '.tumblr'))
+      if File.exist?('./.tumblfetch')
+        $stderr.puts(SETTINGS_EXIST_MSG)
+      else
+        File.open('./.tumblfetch', 'w') do |file|
+          Tumblfetch.write_settings_template_to(file)
+        end
+        puts(SETTINGS_GENERATED_MSG)
       end
-      puts(SETTINGS_GENERATED_MSG)
+    else
+      $stderr.puts(EXECUTE_TUMBLR_MSG)
     end
   end
 end

--- a/spec/lib/tumblfetch/cli_spec.rb
+++ b/spec/lib/tumblfetch/cli_spec.rb
@@ -8,6 +8,14 @@ describe CLI do
   end
 
   describe '#init' do
+    context 'when ~/.tumblr is nonexistent' do
+      it 'should print execute `tumblr`' do
+        File.stub(:exist?).and_return(false)
+        msg = capture(:stderr) { CLI.new.invoke('init') }
+        expect(msg).to include CLI::EXECUTE_TUMBLR_MSG
+      end
+    end
+
     context 'when .tumblfetch is nonexistent' do
       it 'should generate a .tumblfetch' do
         capture(:stdout) { CLI.new.invoke('init') }


### PR DESCRIPTION
CLI#initは~/.tumblrの存在をチェックして、無ければ`tumblr`コマンドを実行するように促す。
